### PR TITLE
fix docker compose development file

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -6,12 +6,8 @@ services:
       - .env.development
     container_name: postgres_container
     image: postgres
-    environment:
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      PGDATA: /data/postgres
     volumes:
-       - ./postgres:/data/postgres
+       - book-service-postgres:/data/postgres
     ports:
       - "5432:5432"
     networks:
@@ -21,3 +17,5 @@ services:
 networks:
   postgres:
     driver: bridge
+volumes:
+  book-service-postgres:


### PR DESCRIPTION
- Remove  `volumes:- ./postgres:/data/postgres` in docker-compose.development.yml file due to some permission error when running GitHub action locally.
- Remove unnecessary environment variables because we already define in the `.env.development` file
       